### PR TITLE
patch URL for packaging tutorial in build.rst

### DIFF
--- a/docs/src/quickstart/build.rst
+++ b/docs/src/quickstart/build.rst
@@ -13,7 +13,7 @@ Cython code must, unlike Python, be compiled. This happens in two stages:
    
 To understand fully the Cython + setuptools build process,
 one may want to read more about
-`distributing Python modules <https://docs.python.org/3/distributing/index.html>`_.
+`distributing Python modules <https://packaging.python.org/en/latest/tutorials/packaging-projects/>`_.
 
 There are several ways to build Cython code:
 


### PR DESCRIPTION
the URL returns a redirection page.
I replaced the URL with the new one, so you can get there immediately